### PR TITLE
feat: remove laravel 11 support and adjust php version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,26 +9,22 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.2, 8.3, 8.4, 8.5]
-        laravel: [11.*, 12.*, 13.*]
+        php: [8.4, 8.5]
+        laravel: [12.*, 13.*]
         phpunit: [11.*, 12.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 11.*
-            testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
           - laravel: 13.*
             testbench: 11.*
         exclude:
-          - laravel: 11.*
-            phpunit: 12.*
           - laravel: 12.*
             phpunit: 12.*
           - laravel: 13.*
             phpunit: 11.*
           - laravel: 13.*
-            php: 8.2
+            php: 8.4
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - U${{ matrix.phpunit }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,8 +23,6 @@ jobs:
             phpunit: 12.*
           - laravel: 13.*
             phpunit: 11.*
-          - laravel: 13.*
-            php: 8.4
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - U${{ matrix.phpunit }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.4, 8.5]
+        php: [8.3, 8.4, 8.5]
         laravel: [12.*, 13.*]
         phpunit: [11.*, 12.*]
         dependency-version: [prefer-lowest, prefer-stable]

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.4",
+        "php": "^8.3",
         "illuminate/console": "^12.0|^13.0",
         "illuminate/support": "^12.0|^13.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,13 @@
         }
     ],
     "require": {
-        "php": "^8.2",
-        "illuminate/console": "^11.0|^12.0|^13.0",
-        "illuminate/support": "^11.0|^12.0|^13.0"
+        "php": "^8.4",
+        "illuminate/console": "^12.0|^13.0",
+        "illuminate/support": "^12.0|^13.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.4",
-        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "orchestra/testbench": "^10.0|^11.0",
         "phpunit/phpunit": "^11.5.3|^12.0",
         "squizlabs/php_codesniffer": "^3.6"
     },


### PR DESCRIPTION
This pull request updates the package to require newer versions of PHP and Laravel, and adjusts the test matrix accordingly. The main goal is to drop support for older versions and ensure compatibility with the latest releases.

**Dependency and compatibility updates:**

- Updated the minimum PHP requirement to `^8.4` and removed support for PHP 8.2 and 8.3 in both `composer.json` and the GitHub Actions test matrix. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L19-R25) [[2]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL12-R27)
- Dropped support for Laravel 11 and updated dependencies to require `illuminate/console` and `illuminate/support` versions `^12.0|^13.0` only. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L19-R25) [[2]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL12-R27)
- Updated `orchestra/testbench` to support only versions `^10.0|^11.0`, removing support for version 9. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L19-R25) [[2]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL12-R27)

**Test matrix adjustments:**

- Simplified the GitHub Actions test matrix by removing combinations for unsupported PHP and Laravel versions, ensuring tests only run for supported configurations.

Ref: #59909